### PR TITLE
Handle legacy country codes

### DIFF
--- a/src/commonMain/kotlin/com/jillesvangurp/koiso/country/all-countries.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/koiso/country/all-countries.kt
@@ -1,8 +1,15 @@
 package com.jillesvangurp.koiso.country
 
 internal val commonAlpha2AliasCodes = mapOf(
-    "UK" to "GB",
-    "EL" to "GR"
+    "UK" to "GB", // United Kingdom legacy code
+    "EL" to "GR", // Greece legacy code
+    "SU" to "RU", // Soviet Union -> Russia
+    "TP" to "TL", // East Timor -> Timor-Leste
+    "YU" to "RS", // Yugoslavia -> Serbia
+    "FX" to "FR", // Metropolitan France -> France
+    "DD" to "DE", // East Germany -> Germany
+    "ZR" to "CD", // Zaire -> Congo, Democratic Republic of the
+    "BU" to "MM"  // Burma -> Myanmar
 )
 
 /**

--- a/src/commonTest/kotlin/com/jillesvangurp/koiso/country/CountryTest.kt
+++ b/src/commonTest/kotlin/com/jillesvangurp/koiso/country/CountryTest.kt
@@ -34,4 +34,15 @@ class CountryTest {
         Country.findByAlpha2("EL")?.alpha2 shouldBe "GR"
         Country.findByAlpha2("EL")?.alpha2Alias shouldBe "EL"
     }
+
+    @Test
+    fun shouldResolveLegacyAlpha2Codes() {
+        Country.findByAlpha2("SU")?.alpha2 shouldBe "RU"
+        Country.findByAlpha2("TP")?.alpha2 shouldBe "TL"
+        Country.findByAlpha2("YU")?.alpha2 shouldBe "RS"
+        Country.findByAlpha2("FX")?.alpha2 shouldBe "FR"
+        Country.findByAlpha2("DD")?.alpha2 shouldBe "DE"
+        Country.findByAlpha2("ZR")?.alpha2 shouldBe "CD"
+        Country.findByAlpha2("BU")?.alpha2 shouldBe "MM"
+    }
 }


### PR DESCRIPTION
## Summary
- support a number of old alpha‑2 codes by keeping an alias table
- test legacy code resolution

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841d397e5f0832e93ef8a80c8cebe17