### PR TITLE
Improve KDoc for public APIs

### DIFF
--- a/src/commonMain/kotlin/com/jillesvangurp/koiso/continent/Continent.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/koiso/continent/Continent.kt
@@ -77,11 +77,11 @@ enum class Continent(
         fun fromAlpha2(code: String): Continent? =
             entries.firstOrNull { it.alpha2.equals(code, ignoreCase = true) }
 
-        /** Lookup by UN M49 numeric code. */
+        /** Lookup by [UN&nbsp;M49](https://en.wikipedia.org/wiki/UN_M49) numeric code. */
         fun fromM49(code: Int): Continent? =
             entries.firstOrNull { it.m49 > 0 && it.m49 == code }
 
-        /** Flexible resolver accepting either code type or enum name. */
+        /** Flexible resolver accepting either alpha-2 code, UN M49 numeric code or enum name. */
         fun resolve(codeOrName: String): Continent? =
             fromAlpha2(codeOrName)
                 ?: codeOrName.toIntOrNull()?.let { fromM49(it) }

--- a/src/commonMain/kotlin/com/jillesvangurp/koiso/country/Country.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/koiso/country/Country.kt
@@ -21,7 +21,12 @@ internal data class CountryMeta(
 )
 
 @Serializable
+/**
+ * Representation of a nation as defined in
+ * [ISO&nbsp;3166‑1](https://en.wikipedia.org/wiki/ISO_3166-1).
+ */
 data class Country(
+    /** The localized name of the country */
     val name: String,
     @SerialName("alpha-2")
     val alpha2: String,
@@ -52,7 +57,8 @@ data class Country(
     val intermediateRegionCode: String? = null
 ) {
     /**
-     * Returns unofficial alternative codes such as UK or EL for GB and GR respectively or null otherwise.
+     * Unofficial alternative 2-letter codes such as `UK` for Great Britain or
+     * `EL` for Greece. Returns `null` if no alias exists.
      */
     val alpha2Alias get() = if(alpha2 in commonAlpha2AliasCodes.values) commonAlpha2AliasCodes.entries.first { it.value == alpha2 }.key else null
     // original data uses "" instead of null as it should have
@@ -74,6 +80,7 @@ data class Country(
     }
 
     companion object {
+        /** All countries parsed from the bundled dataset. */
         val countries: List<Country> by lazy {
             DEFAULT_JSON.decodeFromString(ListSerializer(serializer()), allCountriesJson)
         }
@@ -94,21 +101,28 @@ data class Country(
     }
 }
 
+/** Emoji flag for this country if available. */
 val Country.flag get() = Country.countryMeta[alpha2]?.flag
+
+/** International dialing prefix in the form `+xx`. */
 val Country.dialCode get() = Country.countryMeta[alpha2]?.dialCode
 
+/** Lookup a country by its [ISO&nbsp;3166‑1 alpha‑2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code. */
 fun Country.Companion.findByAlpha2(alpha2: String): Country? {
     return countryAlpha2Map[alpha2.uppercase()] ?: commonAlpha2AliasCodes[alpha2]?.let { countryAlpha2Map[it] }
 }
 
+/** Lookup a country by its [ISO&nbsp;3166‑1 alpha‑3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code. */
 fun Country.Companion.findByAlpha3(alpha3: String): Country? {
     return countryAlpha3Map[alpha3.uppercase()]
 }
 
+/** Lookup a country by its numeric [ISO&nbsp;3166‑1](https://en.wikipedia.org/wiki/ISO_3166-1_numeric) code. */
 fun Country.Companion.findByCountryCode(code: String): Country? {
     return code.toIntOrNull()?.let { countryCodeMap[it] }
 }
 
+/** Resolve [codeOrName] using alpha‑2, alpha‑3, numeric codes or a case-insensitive country name. */
 fun Country.Companion.resolve(codeOrName: String): Country? {
     return findByAlpha2(codeOrName)
         ?: findByAlpha3(codeOrName)
@@ -116,6 +130,7 @@ fun Country.Companion.resolve(codeOrName: String): Country? {
         ?: countries.find { it.name.equals(codeOrName, ignoreCase = true) }
 }
 
+/** Returns the [Continent] this country belongs to. */
 val Country.continent: Continent
     get() = when (region) {
         "Africa" -> Continent.AFRICA

--- a/src/commonMain/kotlin/com/jillesvangurp/koiso/language/Language.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/koiso/language/Language.kt
@@ -26,17 +26,25 @@ enum class LanguageSource {
     ISO_639_3,
 }
 
+/**
+ * Representation of a language from
+ * [ISO&nbsp;639‑2](https://en.wikipedia.org/wiki/ISO_639-2) or
+ * [ISO&nbsp;639‑3](https://en.wikipedia.org/wiki/ISO_639-3).
+ */
 data class Language(
     val code: String,
     val english: List<String>,
     val native: List<String>,
     val source: LanguageSource
 ) {
+    /** Convenience access to the first English name. */
     val name get() = english.first()
 
     override fun toString(): String = "$code: ${(english+native).distinct().joinToString("/")}"
 
+    /** `true` if the language is referenced by a 2-letter code. */
     val isAlpha2 get() = code.length == 2
+    /** `true` if the language is referenced by a 3-letter code. */
     val isAlpha3 get() = code.length == 3
 
     companion object {
@@ -63,11 +71,20 @@ data class Language(
             }
         }
 
+        /**
+         * Lookup a language by its 2- or 3-letter ISO code.
+         * Searches both the [ISO&nbsp;639‑2](https://en.wikipedia.org/wiki/ISO_639-2)
+         * and [ISO&nbsp;639‑3](https://en.wikipedia.org/wiki/ISO_639-3) datasets.
+         */
         fun resolve(code: String): Language? {
             val lowercaseCode = code.lowercase()
             return iso639_2_languages[lowercaseCode] ?: iso639_3_languages[lowercaseCode]
         }
 
+        /**
+         * Search languages by name or code. When [fuzzy] is `true`, a fuzzy
+         * match based on Levenshtein distance is used.
+         */
         fun search(query: String, fuzzy: Boolean = false): List<Language> {
             fun levenshteinDistance(s1: String, s2: String): Int {
                 val previous = IntArray(s2.length + 1) { it }

--- a/src/commonMain/kotlin/com/jillesvangurp/koiso/locale/Locale.kt
+++ b/src/commonMain/kotlin/com/jillesvangurp/koiso/locale/Locale.kt
@@ -4,7 +4,9 @@ import com.jillesvangurp.koiso.country.Country
 import com.jillesvangurp.koiso.language.Language
 
 /**
- * Represents a locale with language, optional country, and optional variant.
+ * Representation of a locale with a language, an optional country, and an optional variant.
+ * Language tags are formatted according to
+ * [BCP&nbsp;47](https://en.wikipedia.org/wiki/IETF_language_tag).
  */
 data class Locale(
     val language: Language,
@@ -12,7 +14,7 @@ data class Locale(
     val variant: String? = null
 ) {
     /**
-     * Returns a BCP-47 compliant language tag.
+     * Returns a [BCP&nbsp;47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag.
      * The country is formatted using its upper-case country code if available.
      */
     fun toLanguageTag(): String {
@@ -31,11 +33,10 @@ data class Locale(
 
     companion object {
         /**
-         * Parses a BCP-47 tag (e.g. "en-US" or "en") into a Locale.
-         * The [resolveLanguage] and [resolveCountry] functions are used to map string codes
-         * to their corresponding Language and Country objects.
-         *
-         * Returns null if the language part of the tag cannot be resolved.
+         * Parse a [BCP&nbsp;47](https://en.wikipedia.org/wiki/IETF_language_tag) tag (e.g. `en-US`)
+         * into a [Locale]. The provided [resolveLanguage] and [resolveCountry] functions
+         * convert the textual codes to [Language] and [Country] instances. Returns `null`
+         * when the language part cannot be resolved.
          */
         fun parse(
             tag: String,


### PR DESCRIPTION
## Summary
- expand API documentation for `Country` and helper lookups
- document `Language` and search helpers
- clarify `Locale` documentation with BCP‑47 link
- add links to UN M49 in `Continent` docs

## Testing
- `./gradlew jvmTest --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec3b2f38832ebf8d08efa1ba8f81